### PR TITLE
Add Callback Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,6 +69,7 @@
         "xmemory": "cpp",
         "xstddef": "cpp",
         "iostream": "cpp",
-        "iomanip": "cpp"
+        "iomanip": "cpp",
+        "variant": "cpp"
     },
 }

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -42,6 +42,9 @@ constexpr void for_each(Tuple&& tuple, F&& f)
     );
 }
 
+template <typename T> struct tag {};
+template <typename T> auto from_tag(tag<T>) -> std::decay_t<T>;
+
 }
 
 template <typename T> class generator;
@@ -370,6 +373,8 @@ public:
     template <typename T>
     using callback_t = std::function<void(apx::entity, const T&)>;
 
+    inline static constexpr std::tuple<apx::meta::tag<Comps>...> tags{};
+
 private:
     using tuple_type = std::tuple<apx::sparse_set<Comps>...>;
 
@@ -406,7 +411,7 @@ public:
 
     template <typename Comp>
     void on_add(callback_t<Comp>&& callback)
-    { 
+    {
         std::get<std::vector<callback_t<Comp>>>(d_on_add).push_back(std::move(callback));
     }
 

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -73,9 +73,6 @@ public:
     constexpr std::suspend_always initial_suspend() const noexcept { return {}; }
     constexpr std::suspend_always final_suspend() const noexcept { return {}; }
 
-    template <typename U>
-    constexpr std::suspend_never await_transform(U&&) = delete;
-
     void return_void() {}
 
     std::suspend_always yield_value(value_type&& value) noexcept
@@ -373,6 +370,7 @@ public:
     template <typename T>
     using callback_t = std::function<void(apx::entity, const T&)>;
 
+    // A tuple of tag types for metaprogramming purposes
     inline static constexpr std::tuple<apx::meta::tag<Comps>...> tags{};
 
 private:

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -98,17 +98,16 @@ public:
     using promise_type = generator_promise<T>;
     using value_type = typename promise_type::value_type;
 
-    using coroutine_handle = std::coroutine_handle<promise_type>;
     using iterator = generator_iterator<T>;
 
 private:
-    coroutine_handle d_coroutine;
+    std::coroutine_handle<promise_type> d_coroutine;
 
     generator(const generator&) = delete;
     generator& operator=(generator) = delete;
 
 public:
-    explicit generator(coroutine_handle coroutine) noexcept
+    explicit generator(std::coroutine_handle<promise_type> coroutine) noexcept
         : d_coroutine(coroutine)
     {}
 

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -101,9 +101,9 @@ public:
     using coroutine_handle = std::coroutine_handle<promise_type>;
     using iterator = generator_iterator<T>;
 
+private:
     coroutine_handle d_coroutine;
 
-private:
     generator(const generator&) = delete;
     generator& operator=(generator) = delete;
 

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -38,3 +38,21 @@ TEST(registry, size_of_registry)
     reg.clear();
     ASSERT_EQ(reg.size(), 0);
 }
+
+TEST(registry, on_add_callback)
+{
+    apx::registry<foo, bar> reg;
+    std::size_t count = 0;
+    reg.on_add<foo>([&](apx::entity, const foo& component) {
+        ++count;
+    });
+
+    auto e1 = reg.create();
+    reg.add<foo>(e1, {});
+    reg.add<bar>(e1, {}); // Should not increase the count
+
+    auto e2 = reg.create();
+    reg.add<foo>(e2, {});
+
+    ASSERT_EQ(count, 2);
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -94,7 +94,15 @@ TEST(registry, on_remove_callback_reigstry_destructs)
 TEST(registry, for_each_type)
 {
     apx::registry<foo, bar> reg;
-    auto e = reg.create();
+    apx::entity e = reg.create();
+    std::size_t count = 0;
+
+    apx::meta::for_each(reg.tags, [&](auto&& tag) {
+        using T = decltype(apx::meta::from_tag(tag));
+        reg.on_add<T>([&](apx::entity entity, const T&) {
+            ++count;
+        });
+    });
 
     apx::meta::for_each(reg.tags, [&](auto&& tag) {
         using T = decltype(apx::meta::from_tag(tag));
@@ -103,4 +111,5 @@ TEST(registry, for_each_type)
 
     ASSERT_TRUE(reg.has<foo>(e));
     ASSERT_TRUE(reg.has<bar>(e));
+    ASSERT_EQ(count, 2);
 }


### PR DESCRIPTION
- Add `registry::on_add` and `registry::on_remove` to be able to register callbacks to get notified whenever components are added/removed. Currently no way to remove callbacks.
- Added more metaprogramming capability with `apx::meta::tag<T>`. Registries now have an `inline static constexpr` tuple of tags, one for each component type. Allows for looping over the component types in the following way.
```
apx::meta::for_each(registry.tags, [&](auto&& tag) {
    using T = decltype(apx::meta::from_tag(tag));
    ....
});
```
- `template <typename T> auto apx::meta::from_tag(tag<T>) -> std::decay_t<T>` is a function with no implementation intended to be used in unevaluated contexts only.