### PR TITLE
Make `apx::meta::tag<T>` looping less verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ apx::meta::for_each(tuple, [](auto&& element) {
 ```
 This of course needs to be generic lambda as this gets invoked for each typle in the tuple.
 
-In extension to the above, you may also find yourself needing to loop over all types within a reigstry. This can be achieved by creating a tuple of `apx::tag<T>` types and extracting the type from those in a for loop. The library provides some helpers for this. In particular, each registry provides an `inline static constexpr` version of this tuple as `registry<Comps...>::tags` and there is `apx::meta::from_tag(tag)` which is intended to be used in a `declype` expression to get the type:
+In extension to the above, you may also find yourself needing to loop over all types within a reigstry. This can be achieved by creating a tuple of `apx::tag<T>` types and extracting the type from those in a for loop. The library provides some helpers for this. In particular, each registry provides an `inline static constexpr` version of this tuple as `registry<Comps...>::tags` and there is `apx::meta::tag<T>::type()` which is intended to be used in a `declype` expression to get the type:
 ```cpp
 apx::meta::for_each(registry.tags, [](auto&& tag) {
-  using T = decltype(apx::meta::from_tag(tag));
+  using T = decltype(tag.type());
   ...
 });
 ```

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -345,7 +345,7 @@ enum class entity : std::uint64_t {};
 using index_t = std::uint32_t;
 using version_t = std::uint32_t;
 
-static const apx::entity null{std::numeric_limits<std::uint64_t>::max()};
+static constexpr apx::entity null{std::numeric_limits<std::uint64_t>::max()};
 
 inline std::pair<index_t, version_t> split(apx::entity id)
 {

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -42,8 +42,10 @@ constexpr void for_each(Tuple&& tuple, F&& f)
     );
 }
 
-template <typename T> struct tag {};
-template <typename T> auto from_tag(tag<T>) -> std::decay_t<T>;
+template <typename T> struct tag
+{
+    static T type(); // Not implmented, to be used with decltype 
+};
 
 }
 

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -98,14 +98,14 @@ TEST(registry, for_each_type)
     std::size_t count = 0;
 
     apx::meta::for_each(reg.tags, [&](auto&& tag) {
-        using T = decltype(apx::meta::from_tag(tag));
+        using T = decltype(tag.type());
         reg.on_add<T>([&](apx::entity entity, const T&) {
             ++count;
         });
     });
 
     apx::meta::for_each(reg.tags, [&](auto&& tag) {
-        using T = decltype(apx::meta::from_tag(tag));
+        using T = decltype(tag.type());
         reg.add<T>(e, {});
     });
 


### PR DESCRIPTION
- Replace `apx::meta::from_tag(tag<T>)` with `apx::meta::tag<T>::type()`, making the looping of types less verbose.
- The return value of this is `T` as oppose to `std::decay_t<T>`, as there was no real need here to decay the value.
- Made `apx::null` constexpr.