### PR TITLE
Add `Registry::handle_type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,6 @@ apx::meta::for_each(registry.tags, []<typename T>(apx::meta::tag<T>) {
 ```
 
 ## Upcoming Features
-- `apx::registry::emplace(...)` to construct components in place with minimal allocations.
-- `const`ness for getting components. That is, a version of `apx::get<T>` that is const and returns a `const T&`, as well as allowing `apx::get<const T>` to be explicit.
 - The ability to deregister callbacks.
 - A slower way of iterating components that allows for deleting and inserting new components. See `apx::sparse_set::safe` vs `apx::sparse_set::fast` for more info.
 - Potentially `apx::handle` based versions for `registry::all` and `registry::view`.

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -372,6 +372,9 @@ inline apx::index_t to_index(apx::entity entity)
 }
 
 template <typename... Comps>
+class handle;
+
+template <typename... Comps>
 class registry
 {
 public:
@@ -380,6 +383,8 @@ public:
 
     // A tuple of tag types for metaprogramming purposes
     inline static constexpr std::tuple<apx::meta::tag<Comps>...> tags{};
+
+    using handle_type = apx::handle<Comps...>;
 
 private:
     using tuple_type = std::tuple<apx::sparse_set<Comps>...>;


### PR DESCRIPTION
- Adds `Reigstry::handle_type`.
- Updates README as it still listed some upcoming features which we implemented in the last commit.