### PR TITLE
Simplify `meta` Implmentation

### DIFF
--- a/apecs.hpp
+++ b/apecs.hpp
@@ -18,10 +18,10 @@ template <typename T, typename Tuple>
 struct tuple_contains;
 
 template <typename T, typename... Ts>
-struct tuple_contains<T, std::tuple<Ts...>> : std::conditional_t<
-    (std::is_same_v<T, Ts> || ...), std::true_type, std::false_type
->
-{};
+struct tuple_contains<T, std::tuple<Ts...>>
+{
+    static constexpr bool value = (std::is_same_v<T, Ts> || ...);
+};
 
 template <typename T, typename Tuple>
 inline constexpr bool tuple_contains_v = tuple_contains<T, Tuple>::value;

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -20,7 +20,8 @@ struct tuple_contains;
 template <typename T, typename... Ts>
 struct tuple_contains<T, std::tuple<Ts...>> : std::conditional_t<
     (std::is_same_v<T, Ts> || ...), std::true_type, std::false_type
-> {};
+>
+{};
 
 template <typename T, typename Tuple>
 inline constexpr bool tuple_contains_v = tuple_contains<T, Tuple>::value;
@@ -584,7 +585,7 @@ class handle
     apx::entity              entity;
 
 public:
-    handle(apx::registry<Comps...>* r, apx::entity e) : registry(r), entity(e) {}
+    handle(apx::registry<Comps...>& r, apx::entity e) : registry(&r), entity(e) {}
 
     bool valid() noexcept { return registry->valid(entity); }
     void destroy() { registry->destroy(entity); }
@@ -617,7 +618,7 @@ public:
 template <typename... Comps>
 inline apx::handle<Comps...> create_from(apx::registry<Comps...>& registry)
 {
-    return {&registry, registry.create()};
+    return {registry, registry.create()};
 }
 
 }


### PR DESCRIPTION
- `meta::for_each` is now a one liner implemented with `std::apply`.
- `meta::tuple_contains` has also been simplified to a one line implementation using a fold expression.