### PR TITLE
Several Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
     ./tests/generator.cpp
     ./tests/sparse_set.cpp
     ./tests/registry.cpp
+    ./tests/handle.cpp
 )
 
 target_link_libraries(

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -477,27 +477,13 @@ public:
     }
 
     template <typename Comp>
-    Comp& add(apx::entity entity, const Comp& component)
-    {
-        static_assert(apx::meta::tuple_contains<apx::sparse_set<Comp>, tuple_type>::value);
-        assert(valid(entity));
-
-        auto& comp_set = get_component_set<Comp>();
-        auto& ret = comp_set.insert(apx::to_index(entity), component);
-        for (auto& cb : std::get<std::vector<callback_t<Comp>>>(d_on_add)) {
-            cb(entity, ret);
-        }
-        return ret;
-    }
-
-    template <typename Comp>
     Comp& add(apx::entity entity, Comp&& component)
     {
         static_assert(apx::meta::tuple_contains<apx::sparse_set<Comp>, tuple_type>::value);
         assert(valid(entity));
 
         auto& comp_set = get_component_set<Comp>();
-        auto& ret = comp_set.insert(apx::to_index(entity), std::move(component));
+        auto& ret = comp_set.insert(apx::to_index(entity), std::forward<Comp>(component));
         for (auto cb : std::get<std::vector<callback_t<Comp>>>(d_on_add)) {
             cb(entity, ret);
         }
@@ -587,38 +573,38 @@ public:
 template <typename... Comps>
 class handle
 {
-    apx::registry<Comps...>* registry;
-    apx::entity              entity;
+    apx::registry<Comps...>* d_registry;
+    apx::entity              d_entity;
 
 public:
-    handle(apx::registry<Comps...>& r, apx::entity e) : registry(&r), entity(e) {}
+    handle(apx::registry<Comps...>& r, apx::entity e) : d_registry(&r), d_entity(e) {}
 
-    bool valid() noexcept { return registry->valid(entity); }
-    void destroy() { registry->destroy(entity); }
-
-    template <typename Comp>
-    Comp& add(const Comp& component) { return registry->add<Comp>(entity, component); }
+    bool valid() noexcept { return d_registry->valid(d_entity); }
+    void destroy() { d_registry->destroy(d_entity); }
 
     template <typename Comp>
-    Comp& add(Comp&& component) { return registry->add<Comp>(entity, std::move(component)); }
+    Comp& add(const Comp& component) { return d_registry->template add<Comp>(d_entity, component); }
+
+    template <typename Comp>
+    Comp& add(Comp&& component) { return d_registry->template add<Comp>(d_entity, std::move(component)); }
 
     template <typename Comp, typename... Args>
-    Comp& emplace(Args&&... args) { return registry->emplace<Comp>(entity, std::forward<Args>(args)...); }
+    Comp& emplace(Args&&... args) { return d_registry->template emplace<Comp>(d_entity, std::forward<Args>(args)...); }
 
     template <typename Comp>
-    void remove() { registry->remove<Comp>(entity); }
+    void remove() { d_registry->template remove<Comp>(d_entity); }
 
     template <typename Comp>
-    bool has() { return registry->has<Comp>(entity); }
+    bool has() { return d_registry->template has<Comp>(d_entity); }
 
     template <typename Comp>
-    Comp& get() { return registry->get<Comp>(entity); }
+    Comp& get() { return d_registry->template get<Comp>(d_entity); }
 
     template <typename Comp>
-    const Comp& get() const { return registry->get<Comp>(entity); }
+    const Comp& get() const { return d_registry->template get<Comp>(d_entity); }
 
     template <typename Comp>
-    Comp* get_if() noexcept { return registry->get_if<Comp>(entity); }
+    Comp* get_if() noexcept { return d_registry->template get_if<Comp>(d_entity); }
 };
 
 template <typename... Comps>

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -67,6 +67,12 @@ public:
 
     void return_void() {}
 
+    std::suspend_always yield_value(value_type& value) noexcept
+    {
+        d_val = std::addressof(value);
+        return {};
+    }
+
     std::suspend_always yield_value(value_type&& value) noexcept
     {
         d_val = std::addressof(value);
@@ -570,7 +576,7 @@ public:
     apx::generator<apx::entity> view()
     {
         for (auto [index, component] : get_component_set<T>().fast()) {
-            apx::entity = d_entities[index];
+            apx::entity& entity = d_entities[index];
             if ((has<Ts>(entity) && ...)) {
                 co_yield entity;
             }

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -397,7 +397,7 @@ private:
     void remove(apx::entity entity, apx::sparse_set<Comp>& component_set)
     {
         if (has<Comp>(entity)) {
-            for (auto cb : std::get<std::vector<callback_t<Comp>>>(d_on_remove)) {
+            for (auto& cb : std::get<std::vector<callback_t<Comp>>>(d_on_remove)) {
                 cb(entity, get<Comp>(entity));
             }
             component_set.erase(apx::to_index(entity));
@@ -484,7 +484,7 @@ public:
 
         auto& comp_set = get_component_set<Comp>();
         auto& ret = comp_set.insert(apx::to_index(entity), component);
-        for (auto cb : std::get<std::vector<callback_t<Comp>>>(d_on_add)) {
+        for (auto& cb : std::get<std::vector<callback_t<Comp>>>(d_on_add)) {
             cb(entity, ret);
         }
         return ret;

--- a/tests/handle.cpp
+++ b/tests/handle.cpp
@@ -1,0 +1,19 @@
+#include "apecs.hpp"
+#include <gtest/gtest.h>
+
+struct foo {};
+struct bar {};
+
+TEST(handle, handle_basics)
+{
+    apx::registry<foo, bar> reg;
+    apx::handle h = apx::create_from(reg);
+
+    h.emplace<foo>();
+    ASSERT_TRUE(h.has<foo>());
+
+    h.remove<foo>();
+    ASSERT_FALSE(h.has<foo>());
+
+    ASSERT_EQ(h.get_if<foo>(), nullptr);
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -143,3 +143,15 @@ TEST(registry, test_noexcept_get)
     bar* bar_get = reg.get_if<bar>(e);
     ASSERT_EQ(bar_get, nullptr);
 }
+
+TEST(handle, handle_basics)
+{
+    apx::registry<foo, bar> reg;
+    apx::handle h = apx::create_from(reg);
+
+    h.emplace<foo>();
+    ASSERT_TRUE(h.has<foo>());
+
+    h.remove<foo>();
+    ASSERT_FALSE(h.has<foo>());
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -15,22 +15,6 @@ TEST(registry, entity_invalid_after_destroying)
     ASSERT_FALSE(reg.valid(e));
 }
 
-TEST(registry, views)
-{
-    apx::registry<foo, bar> reg;
-
-    auto e1 = reg.create();
-    auto e2 = reg.create();
-
-    reg.emplace<foo>(e1);
-
-    std::size_t count = 0;
-    for (auto entity : reg.view<foo>()) {
-        ++count;
-    }
-    ASSERT_EQ(count, 1);
-}
-
 TEST(registry, size_of_registry)
 {
     apx::registry<foo, bar> reg;
@@ -87,7 +71,7 @@ TEST(registry, on_remove_callback)
     ASSERT_EQ(count, 1);
 }
 
-TEST(registry, on_remove_callback_reigstry_destructs)
+TEST(registry, on_remove_callback_registry_destructs)
 {
     std::size_t count = 0;
 
@@ -104,6 +88,25 @@ TEST(registry, on_remove_callback_reigstry_destructs)
         reg.add<foo>(e2, {});
     }
 
+    ASSERT_EQ(count, 2);
+}
+
+TEST(registry, on_remove_callback_registry_cleared)
+{
+    std::size_t count = 0;
+
+    apx::registry<foo, bar> reg;
+    reg.on_remove<foo>([&](apx::entity, const foo& component) {
+        ++count;
+    });
+
+    auto e1 = reg.create();
+    reg.add<foo>(e1, {});
+
+    auto e2 = reg.create();
+    reg.add<foo>(e2, {});
+
+    reg.clear();
     ASSERT_EQ(count, 2);
 }
 
@@ -144,14 +147,38 @@ TEST(registry, test_noexcept_get)
     ASSERT_EQ(bar_get, nullptr);
 }
 
-TEST(handle, handle_basics)
+TEST(registry, registry_view)
 {
     apx::registry<foo, bar> reg;
-    apx::handle h = apx::create_from(reg);
 
-    h.emplace<foo>();
-    ASSERT_TRUE(h.has<foo>());
+    auto e1 = reg.create();
+    reg.emplace<foo>(e1);
+    reg.emplace<bar>(e1);
 
-    h.remove<foo>();
-    ASSERT_FALSE(h.has<foo>());
+    auto e2 = reg.create();
+    reg.emplace<bar>(e2);
+
+    std::size_t count = 0;
+    for (auto entity : reg.view<foo>()) {
+        ++count;
+    }
+    ASSERT_EQ(count, 1);
+}
+
+TEST(registry, registry_all)
+{
+    apx::registry<foo, bar> reg;
+
+    auto e1 = reg.create();
+    reg.emplace<foo>(e1);
+    reg.emplace<bar>(e1);
+
+    auto e2 = reg.create();
+    reg.emplace<bar>(e2);
+
+    std::size_t count = 0;
+    for (auto entity : reg.all()) {
+        ++count;
+    }
+    ASSERT_EQ(count, 2);
 }

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -15,6 +15,22 @@ TEST(registry, entity_invalid_after_destroying)
     ASSERT_FALSE(reg.valid(e));
 }
 
+TEST(registry, views)
+{
+    apx::registry<foo, bar> reg;
+
+    auto e1 = reg.create();
+    auto e2 = reg.create();
+
+    reg.emplace<foo>(e1);
+
+    std::size_t count = 0;
+    for (auto entity : reg.view<foo>()) {
+        ++count;
+    }
+    ASSERT_EQ(count, 1);
+}
+
 TEST(registry, size_of_registry)
 {
     apx::registry<foo, bar> reg;


### PR DESCRIPTION
- Remove `registry::add<Comp>(apx::entity, const Comp&)` as we have `registry::add<Comp>(apx::entity, Comp&&)`, and fix the latter to use `std::forward`.
- When looping over the callbacks, use `auto&` to avoid unnecessary copies.
- Fix a typo in `registry::view<T>`.
- Make naming of variables in `apx::handle` consistent with the rest of the library, and use `template` keyword to allow for compiling with gcc. I'll be doing more testing on other platforms in the future.