### PR TITLE
Generator Iterator Type Traits

### DIFF
--- a/apecs.hpp
+++ b/apecs.hpp
@@ -157,21 +157,30 @@ public:
     struct sentinel {};
 
 private:
-    generator<T>& d_owner;
+    generator<T>* d_owner;
 
 public:
     explicit generator_iterator(generator<T>& owner) noexcept
-        : d_owner(owner)
-    {}
+        : d_owner(&owner)
+    {
+        static_assert(std::is_copy_assignable_v<generator_iterator<T>>);
+        static_assert(std::is_trivially_destructible_v<generator_iterator<T>>);
+    }
+
+    generator_iterator& operator=(const generator_iterator& other)
+    {
+        d_owner = other.d_owner;
+        return *this;
+    }
 
     friend bool operator==(const generator_iterator& it, sentinel) noexcept
     {
-        return !it.d_owner.valid();
+        return !it.d_owner->valid();
     }
 
     generator_iterator& operator++()
     {
-        d_owner.advance();
+        d_owner->advance();
         return *this;
     }
 
@@ -179,7 +188,7 @@ public:
 
     [[nodiscard]] value_type& operator*() const noexcept
     {
-        return d_owner.value();
+        return d_owner->value();
     }
 
     [[nodiscard]] value_type* operator->() const noexcept


### PR DESCRIPTION
I have a personal game engine project that I am currently migrating to use library away from the less robust precursor. For this, the `generator_iterator<T>` needs to satisfy a few properties; namely that is must satisfy `std::is_trivially_destructible` and `std::is_copy_assignable`.

The reason for this is that I have embedded Lua and in order to allow entity iteration in scripts, the iterator gets created directly in the Lua stack. The copy assignable is so that I can assign to the memory allocated in the stack, and the trivially destructible is so that the Lua garbage collector can delete it later.

It may be that these are restrictive requirements, however I don't think that's the case with the current implementation; currently, the `generator_iterator<T>` isn't really an iterator in the classic sense, as the "position" that it is currently at is really stored inside the `generator<T>`. Thus, the iterator is more of a view that can fetch the value and advance, but it is not possible to have two iterators at different points. So copying these things is fine so long as the user knows that all iterators point to the same value, and trivial destruction is fine since it only has a handle back to the generator.

- Add `static_assert`s into the `generator_iterator<T>` constructor to properly codify these requirements.
- `generator_iterator<T>` now stores a pointer to the `generator<T>` rather than a reference since it needs to be reassignable.