### PR TITLE
More Enhancements

### DIFF
--- a/apecs.hpp
+++ b/apecs.hpp
@@ -17,8 +17,7 @@ template <typename T, typename Tuple>
 struct tuple_contains;
 
 template <typename T, typename... Ts>
-struct tuple_contains<T, std::tuple<Ts...>> : std::bool_constant<(std::is_same_v<T, Ts> || ...)>
-{};
+struct tuple_contains<T, std::tuple<Ts...>> : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
 
 template <typename T, typename Tuple>
 inline constexpr bool tuple_contains_v = tuple_contains<T, Tuple>::value;
@@ -33,6 +32,15 @@ template <typename T> struct tag
 {
     static T type(); // Not implmented, to be used with decltype
 };
+
+template <typename... Ts>
+struct get_first;
+
+template <typename T, typename... Ts>
+struct get_first<T, Ts...> { using type = T; };
+
+template <typename... Ts>
+using get_first_t = typename get_first<Ts...>::type;
 
 }
 
@@ -106,6 +114,10 @@ private:
 public:
     explicit generator(std::coroutine_handle<promise_type> coroutine) noexcept
         : d_coroutine(coroutine)
+    {}
+
+    explicit generator(generator&& other)
+        : d_coroutine(std::move(other.d_coroutine))
     {}
 
     ~generator()
@@ -482,14 +494,30 @@ public:
     }
 
     template <typename Comp>
-    Comp& add(const apx::entity entity, Comp&& component)
+    Comp& add(const apx::entity entity, const Comp& component)
     {
-        static_assert(apx::meta::tuple_contains_v<apx::sparse_set<Comp>, tuple_type>);
+        using T = std::remove_cvref_t<Comp>;
+        static_assert(apx::meta::tuple_contains_v<apx::sparse_set<T>, tuple_type>);
         assert(valid(entity));
 
-        auto& comp_set = get_comps<Comp>();
+        auto& comp_set = get_comps<T>();
+        auto& ret = comp_set.insert(apx::to_index(entity), component);
+        for (auto cb : std::get<std::vector<callback_t<T>>>(d_on_add)) {
+            cb(entity, ret);
+        }
+        return ret;
+    }
+
+    template <typename Comp>
+    Comp& add(const apx::entity entity, Comp&& component)
+    {
+        using T = std::remove_cvref_t<Comp>;
+        static_assert(apx::meta::tuple_contains_v<apx::sparse_set<T>, tuple_type>);
+        assert(valid(entity));
+
+        auto& comp_set = get_comps<T>();
         auto& ret = comp_set.insert(apx::to_index(entity), std::forward<Comp>(component));
-        for (auto cb : std::get<std::vector<callback_t<Comp>>>(d_on_add)) {
+        for (auto cb : std::get<std::vector<callback_t<T>>>(d_on_add)) {
             cb(entity, ret);
         }
         return ret;
@@ -558,9 +586,7 @@ public:
 
     [[nodiscard]] apx::generator<apx::entity> all() noexcept
     {
-        for (auto [index, entity] : d_entities.fast()) {
-            co_yield entity;
-        }
+        return view();
     }
 
     void all(const std::function<void(apx::entity)>& cb)
@@ -570,30 +596,39 @@ public:
         }
     }
 
-    template <typename T, typename... Ts>
+    template <typename... Ts>
     [[nodiscard]] apx::generator<apx::entity> view()
     {
-        for (auto [index, component] : get_comps<T>().fast()) {
-            apx::entity entity = d_entities[index];
-            if ((has<Ts>(entity) && ...)) {
+        if constexpr (sizeof...(Ts) > 0) {
+            using T = apx::meta::get_first_t<Ts...>;
+            for (auto [index, component] : get_comps<T>().fast()) {
+                apx::entity entity = d_entities[index];
+                if ((has<Ts>(entity) && ...)) {
+                    co_yield entity;
+                }
+            }
+        } else {
+            for (auto [index, entity] : d_entities.fast()) {
                 co_yield entity;
             }
         }
     }
 
     template <typename... Ts>
-    void view(const std::function<void(apx::entity)>& cb) {
-        static_assert(sizeof...(Ts) > 0);
+    void view(const std::function<void(apx::entity, Ts&...)>& cb) {
         for (apx::entity entity : view<Ts...>()) {
-            cb(entity);
+            cb(entity, get<Ts>(entity)...);
         }
     }
 
     template <typename... Ts>
-    void view(const std::function<void(apx::entity, Ts&...)>& cb) {
-        static_assert(sizeof...(Ts) > 0);
-        for (apx::entity entity : view<Ts...>()) {
-            cb(entity, get<Ts>(entity)...);
+    void erase_if(const std::function<bool(apx::entity)>& cb) {
+        std::vector<apx::entity> to_delete;
+        for (auto entity : view<Ts...>()) {
+            if (cb(entity)) { to_delete.push_back(entity); }
+        }
+        for (auto entity : to_delete) {
+            destroy(entity);
         }
     }
 };
@@ -606,6 +641,9 @@ class handle
 
 public:
     handle(apx::registry<Comps...>& r, const apx::entity e) : d_registry(&r), d_entity(e) {}
+    explicit constexpr handle() : d_registry(nullptr), d_entity(apx::null) {}
+
+    apx::entity entity() const { return d_entity; }
 
     [[nodiscard]] bool valid() noexcept { return d_registry->valid(d_entity); }
     void destroy() { d_registry->destroy(d_entity); }
@@ -614,7 +652,7 @@ public:
     Comp& add(const Comp& component) { return d_registry->template add<Comp>(d_entity, component); }
 
     template <typename Comp>
-    Comp& add(Comp&& component) { return d_registry->template add<Comp>(d_entity, std::move(component)); }
+    Comp& add(Comp&& component) { return d_registry->template add<Comp>(d_entity, std::forward<Comp>(component)); }
 
     template <typename Comp, typename... Args>
     Comp& emplace(Args&&... args) { return d_registry->template emplace<Comp>(d_entity, std::forward<Args>(args)...); }
@@ -623,7 +661,7 @@ public:
     void remove() { d_registry->template remove<Comp>(d_entity); }
 
     template <typename Comp>
-    [[nodiscard]] bool has() noexcept { return d_registry->template has<Comp>(d_entity); }
+    [[nodiscard]] bool has() const noexcept { return d_registry->template has<Comp>(d_entity); }
 
     template <typename Comp>
     [[nodiscard]] Comp& get() noexcept { return d_registry->template get<Comp>(d_entity); }
@@ -633,6 +671,13 @@ public:
 
     template <typename Comp>
     [[nodiscard]] Comp* get_if() noexcept { return d_registry->template get_if<Comp>(d_entity); }
+
+    [[nodiscard]] bool operator==(const apx::handle<Comps...>& other) const noexcept
+    {
+        return d_registry == other.d_registry && d_entity == other.d_entity;
+    }
+
+    [[nodiscard]] bool operator!=(const apx::handle<Comps...>& other) const noexcept { return !(*this == other); }
 };
 
 template <typename... Comps>
@@ -640,6 +685,21 @@ inline apx::handle<Comps...> create_from(apx::registry<Comps...>& registry)
 {
     return {registry, registry.create()};
 }
+
+template <typename... Comps>
+static constexpr apx::handle null_handle{};
+
+}
+
+namespace std {
+
+template <typename... Comps>
+struct hash<apx::handle<Comps...>>
+{
+    std::size_t operator()(const apx::handle<Comps...>& handle) const {
+        return std::hash<apx::entity>{}(handle.entity());
+    }
+};
 
 }
 

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -615,6 +615,13 @@ public:
     }
 
     template <typename... Ts>
+    void view(const std::function<void(apx::entity)>& cb) {
+        for (apx::entity entity : view<Ts...>()) {
+            cb(entity);
+        }
+    }
+
+    template <typename... Ts>
     void view(const std::function<void(apx::entity, Ts&...)>& cb) {
         for (apx::entity entity : view<Ts...>()) {
             cb(entity, get<Ts>(entity)...);

--- a/tests/handle.cpp
+++ b/tests/handle.cpp
@@ -21,8 +21,30 @@ TEST(handle, handle_basics)
 TEST(handle, test_add)
 {
     apx::registry<foo> reg;
-    apx::handle h = apx::create_from(reg);
 
-    foo f;
-    h.add<foo>(f);
+    { // lvalue ref, explicit type
+        apx::handle h = apx::create_from(reg);
+        foo f;
+        h.add<foo>(f);
+        ASSERT_TRUE(h.has<foo>());
+    }
+
+    { // rvalue ref, explicit type
+        apx::handle h = apx::create_from(reg);
+        h.add<foo>({});
+        ASSERT_TRUE(h.has<foo>());
+    }
+
+    { // lvalue ref, type deduced
+        apx::handle h = apx::create_from(reg);
+        foo f;
+        h.add(f);
+        ASSERT_TRUE(h.has<foo>());
+    }
+
+    { // rvalue ref, type deduced
+        apx::handle h = apx::create_from(reg);
+        h.add(foo{});
+        ASSERT_TRUE(h.has<foo>());
+    }
 }

--- a/tests/handle.cpp
+++ b/tests/handle.cpp
@@ -17,3 +17,12 @@ TEST(handle, handle_basics)
 
     ASSERT_EQ(h.get_if<foo>(), nullptr);
 }
+
+TEST(handle, test_add)
+{
+    apx::registry<foo> reg;
+    apx::handle h = apx::create_from(reg);
+
+    foo f;
+    h.add<foo>(f);
+}

--- a/tests/handle.cpp
+++ b/tests/handle.cpp
@@ -48,3 +48,24 @@ TEST(handle, test_add)
         ASSERT_TRUE(h.has<foo>());
     }
 }
+
+TEST(handle, test_erase_if)
+// Test removing all but the first element.
+{
+    apx::registry<foo> reg;
+    (void)reg.create();
+    (void)reg.create();
+    (void)reg.create();
+    (void)reg.create();
+
+    bool passed_first = false;
+    reg.erase_if([&](apx::entity e) {
+        if (!passed_first) {
+            passed_first = true;
+            return false;
+        }
+        return true;
+    });
+
+    ASSERT_EQ(reg.size(), 1);
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -179,7 +179,7 @@ TEST(registry_view, view_callback)
     reg.emplace<bar>(e2);
 
     std::size_t count = 0;
-    reg.view<foo>([&](apx::entity) {
+    reg.view<foo>([&](apx::entity, const foo&) {
         ++count;
     });
     ASSERT_EQ(count, 1);

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -240,3 +240,38 @@ TEST(registry_all, all_callback)
     });
     ASSERT_EQ(count, 2);
 }
+
+TEST(registry, test_add)
+// registry::add was actually broken when trying to call with an lvalue reference, but no
+// other tests at the time tested this; they either used emplace passed an rvalue to add
+// which worked fine. This test makes sure add works as expected, and allow both explicit
+// typing and type deduction.
+{
+    apx::registry<foo> reg;
+
+    { // lvalue ref, explicit type
+        apx::entity h = reg.create();
+        foo f;
+        reg.add<foo>(h, f);
+        ASSERT_TRUE(reg.has<foo>(h));
+    }
+
+    { // rvalue ref, explicit type
+        apx::entity h = reg.create();
+        reg.add<foo>(h, {});
+        ASSERT_TRUE(reg.has<foo>(h));
+    }
+
+    { // lvalue ref, type deduced
+        apx::entity h = reg.create();
+        foo f;
+        reg.add(h, f);
+        ASSERT_TRUE(reg.has<foo>(h));
+    }
+
+    { // rvalue ref, type deduced
+        apx::entity h = reg.create();
+        reg.add(h, foo{});
+        ASSERT_TRUE(reg.has<foo>(h));
+    }
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -250,28 +250,28 @@ TEST(registry, test_add)
     apx::registry<foo> reg;
 
     { // lvalue ref, explicit type
-        apx::entity h = reg.create();
+        apx::entity e = reg.create();
         foo f;
-        reg.add<foo>(h, f);
-        ASSERT_TRUE(reg.has<foo>(h));
+        reg.add<foo>(e, f);
+        ASSERT_TRUE(reg.has<foo>(e));
     }
 
     { // rvalue ref, explicit type
-        apx::entity h = reg.create();
-        reg.add<foo>(h, {});
-        ASSERT_TRUE(reg.has<foo>(h));
+        apx::entity e = reg.create();
+        reg.add<foo>(e, {});
+        ASSERT_TRUE(reg.has<foo>(e));
     }
 
     { // lvalue ref, type deduced
-        apx::entity h = reg.create();
+        apx::entity e = reg.create();
         foo f;
-        reg.add(h, f);
-        ASSERT_TRUE(reg.has<foo>(h));
+        reg.add(e, f);
+        ASSERT_TRUE(reg.has<foo>(e));
     }
 
     { // rvalue ref, type deduced
-        apx::entity h = reg.create();
-        reg.add(h, foo{});
-        ASSERT_TRUE(reg.has<foo>(h));
+        apx::entity e = reg.create();
+        reg.add(e, foo{});
+        ASSERT_TRUE(reg.has<foo>(e));
     }
 }

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -179,7 +179,7 @@ TEST(registry_view, view_callback)
     reg.emplace<bar>(e2);
 
     std::size_t count = 0;
-    reg.view<foo>([&](apx::entity, const foo&) {
+    reg.view<foo>([&](apx::entity) {
         ++count;
     });
     ASSERT_EQ(count, 1);


### PR DESCRIPTION
* Added `apx::registry::erase_if<Comps...>` that accepts a predicate and deletes all entities for which is returns `true`. Can optionally provide component types in order to iterate over a smaller view.
* Added a move constructor to `apx::generator<T>`.
* Added back apx::registry::add(const apx::entity entity, const Comp& component). The reason for this is that I want `add` to be callable in the following ways:

    ```cpp
    transform_t instance;
    const transform_t instance2;

    handle.add(instance);
        // (1) lvalue reference, type deduced, already worked by binding to T&& and perfect forwarded,
        // continues to bind to T&& due to the lack of const

    handle.add(instance2);
        // (2) lvalue reference, type deduced, already worked by binding to T&& and perfect forwarded,
        // now binds to the new const T&

    handle.add(transform_t{});
        // (3) rvalue reference, type deduced, already worked by binding to T&& and perfect forwarded,
        // continues to bind to T&&

    handle.add<transform_t>(instance);
        // (4) explicitly state the type, compiler error! This failed because T&& would become transform_t&&,
        // which a transform_t& cannot bind to. Now binds to to const T& and works
    ```
    Admittedly the fourth way is fairly redundant since `emplace` exists, but I like making it explicit in some places.
* Changed the implementation of the `add` functions to use `T = std::remove_cvref_t<Comp>` instead of `Comp`. The reason for this is because in case (1) above, `Comp` would be deduced as `transform_t&`, causing a static assertion failure when trying to access the component vector as the ref needed to be stripped off. Rather awkwardly, this was always a problem, it turns out no unit tests covered this case; the only tests that used `add` passed rvalue references. That has been fixed.
* Added `apx::meta::get_first_t<Ts...>` which returns the first type in the pack.
* Relaxed `view` to be able to take no components, in which case it is equivalent to `all`. This makes implementations like `erase_if` simpler as there doesn't need to be two version provided.
* Implements `std::hash` for `apx::handle<Comps...>`.
* Added equality operators for `apx::handle<Comps...>`.