### PR TITLE
Typeless Handle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
     ./tests/generator.cpp
     ./tests/sparse_set.cpp
     ./tests/fixed_registry.cpp
+    ./tests/fixed_handle.cpp
     ./tests/registry.cpp
     ./tests/handle.cpp
 )

--- a/README.md
+++ b/README.md
@@ -129,11 +129,9 @@ registry.on_remove<transform>([&](apx::entity entity, const transform& component
 If a registry is cleared, all `on_remove` callbacks are invoked for each entity along the way.
 
 ## Entity Handle
-NOTE: This is only implmented for `apx::fixed_registry`. However, I will most likely rename this to `apx::fixed_handle` and implemement the typeless version too.
-
-To some, a call such as `registry.add<transform>(entity, t)` may feel unnatural and would prefer a more traditional object oriented interface such as `entity.add<transform>(t)`. This is provided via `apx::handle`, a thin wrapper around a registry pointer and an entity. Given a reigstry and an entity, a handle can be created easily
+To some, a call such as `registry.add<transform>(entity, t)` may feel unnatural and would prefer a more traditional object oriented interface such as `entity.add<transform>(t)`. This is provided via `apx::fixed_handle<Comps...>` and `apx::handle`, a thin wrapper around a registry pointer and an entity. Given a reigstry and an entity, a handle can be created easily
 ```cpp
-apx::handle handle{&registry, entity};
+apx::handle handle{registry, entity};
 ```
 To make your code prettier, a helper function is provided to create handles when creating a fresh entity
 ```cpp
@@ -145,8 +143,10 @@ handle.valid();
 handle.destroy();
 
 handle.add<transform>(t);
+handle.emplace<transform>(args...);
 handle.has<transform>();
 handle.get<transform>();
+handle.get_if<transform>();
 handle.remove<transform>();
 ```
 

--- a/tests/fixed_handle.cpp
+++ b/tests/fixed_handle.cpp
@@ -4,10 +4,10 @@
 struct foo {};
 struct bar {};
 
-TEST(handle, handle_basics)
+TEST(fixed_handle, fixed_handle_basics)
 {
-    apx::registry reg;
-    apx::handle h = apx::create_from(reg);
+    apx::fixed_registry<foo, bar> reg;
+    apx::fixed_handle h = apx::create_from(reg);
 
     h.emplace<foo>();
     ASSERT_TRUE(h.has<foo>());
@@ -18,41 +18,41 @@ TEST(handle, handle_basics)
     ASSERT_EQ(h.get_if<foo>(), nullptr);
 }
 
-TEST(handle, test_add)
+TEST(fixed_handle, test_add)
 {
-    apx::registry reg;
+    apx::fixed_registry<foo> reg;
 
     { // lvalue ref, explicit type
-        apx::handle h = apx::create_from(reg);
+        apx::fixed_handle h = apx::create_from(reg);
         foo f;
         h.add<foo>(f);
         ASSERT_TRUE(h.has<foo>());
     }
 
     { // rvalue ref, explicit type
-        apx::handle h = apx::create_from(reg);
+        apx::fixed_handle h = apx::create_from(reg);
         h.add<foo>({});
         ASSERT_TRUE(h.has<foo>());
     }
 
     { // lvalue ref, type deduced
-        apx::handle h = apx::create_from(reg);
+        apx::fixed_handle h = apx::create_from(reg);
         foo f;
         h.add(f);
         ASSERT_TRUE(h.has<foo>());
     }
 
     { // rvalue ref, type deduced
-        apx::handle h = apx::create_from(reg);
+        apx::fixed_handle h = apx::create_from(reg);
         h.add(foo{});
         ASSERT_TRUE(h.has<foo>());
     }
 }
 
-TEST(handle, test_erase_if)
+TEST(fixed_handle, test_erase_if)
 // Test removing all but the first element.
 {
-    apx::registry reg;
+    apx::fixed_registry<foo> reg;
     (void)reg.create();
     (void)reg.create();
     (void)reg.create();


### PR DESCRIPTION
* Rename `apx::handle<Comps...>` to `apx::fixed_handle<Comps...>`.
* Add typeless `apx::handle`.