### PR TITLE
Sparse Set Iterators

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,8 @@
         "iomanip": "cpp",
         "variant": "cpp",
         "format": "cpp",
-        "forward_list": "cpp"
+        "forward_list": "cpp",
+        "charconv": "cpp",
+        "optional": "cpp"
     },
 }

--- a/tests/sparse_set.cpp
+++ b/tests/sparse_set.cpp
@@ -21,13 +21,13 @@ TEST(sparse_set, erase)
     ASSERT_FALSE(set.has(2));
 }
 
-TEST(sparse_set, iterate_with_one_element)
+TEST(sparse_set, iterate_with_one_element_and_index_check)
 {
     apx::sparse_set<int> set;
     set.insert(2, 5);
 
-    for (auto [key, value] : set) {
-        ASSERT_EQ(key, 2);
-        ASSERT_EQ(value, 5);
+    for (auto it = set.begin(); it != set.end(); ++it) {
+        ASSERT_EQ(*it, 5);
+        ASSERT_EQ(it.index(), 2);
     }
 }


### PR DESCRIPTION
* The previous implementation of delegating to the internal iterators was that the indexes could be changed, yikes!
* This implementation patches over that with custom iterators. These are not ideal; they should return a pair rather than a value. In the current impl, you need to call `.index()` to get the index, meaning if you need them, you can't use a ranged-for loop.
* However, this works well enough to implement the registry, which is the main thing.