### PR TITLE
Use Ranges Library

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,8 @@
         "format": "cpp",
         "forward_list": "cpp",
         "charconv": "cpp",
-        "optional": "cpp"
+        "optional": "cpp",
+        "ranges": "cpp",
+        "span": "cpp"
     },
 }

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -6,8 +6,9 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
-#include <tuple>
+#include <initializer_list>
 #include <ranges>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -303,6 +304,16 @@ public:
         d_entities.erase(apx::to_index(entity));
     }
 
+    void destroy(const std::span<const apx::entity> entities)
+    {
+        std::ranges::for_each(entities, [&](auto e) { destroy(e); });
+    }
+
+    void destroy(const std::initializer_list<const apx::entity> entities)
+    {
+        std::ranges::for_each(entities, [&](auto e) { destroy(e); });
+    }
+
     [[nodiscard]] std::size_t size() const noexcept
     {
         return d_entities.size();
@@ -463,10 +474,10 @@ public:
     }
 
     template <typename... Ts>
-    void erase_if(const predicate_t& cb) noexcept {
+    void destroy_if(const predicate_t& cb) noexcept {
         auto v = view<Ts...>() | std::views::filter(cb);
         std::vector<apx::entity> to_delete{v.begin(), v.end()};
-        std::ranges::for_each(to_delete, [&](auto entity) { destroy(entity); });
+        destroy(to_delete);
     }
 
     template <typename... Comps>

--- a/apecs.hpp
+++ b/apecs.hpp
@@ -6,6 +6,7 @@
 #include <deque>
 #include <functional>
 #include <tuple>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -32,6 +33,12 @@ template <typename T> struct tag
     static T type(); // Not implmented, to be used with decltype
 };
 
+template <typename... Ts>
+struct get_first;
+
+template <typename T, typename... Ts>
+struct get_first<T, Ts...> { using type = T; };
+
 }
 
 template <typename T>
@@ -43,34 +50,6 @@ public:
 
     using packed_type = std::vector<std::pair<index_type, value_type>>;
     using sparse_type = std::vector<index_type>;
-
-    class iterator
-    {
-        packed_type::iterator d_curr;
-    public:
-        iterator(packed_type::iterator curr) : d_curr(curr) {}
-        value_type& operator*() { return d_curr->second; }
-        value_type* operator->() { return &d_curr->second; }
-        iterator& operator++() { ++d_curr; return *this; }
-        index_type index() const { return d_curr->first; }
-        bool operator==(const iterator& other) const { return d_curr == other.d_curr; }
-        bool operator!=(const iterator& other) const { return !(*this == other); }
-        friend class const_iterator;
-    };
-
-    class const_iterator
-    {
-        packed_type::const_iterator d_curr;
-    public:
-        const_iterator(packed_type::const_iterator curr) : d_curr(curr) {}
-        const_iterator(const iterator& iter) : d_curr(iter.d_curr) {}
-        const value_type& operator*() const { return d_curr->second; }
-        const value_type* operator->() { return &d_curr->second; }
-        const_iterator& operator++() { ++d_curr; return *this; }
-        index_type index() const { return d_curr->first; }
-        bool operator==(const const_iterator& other) const { return d_curr == other.d_curr; }
-        bool operator!=(const const_iterator& other) const { return !(*this == other); }
-    };
 
 private:
     static_assert(std::is_integral<index_type>());
@@ -184,12 +163,19 @@ public:
         return d_packed[d_sparse[index]].second;
     }
 
-    iterator begin() noexcept { return {d_packed.begin()}; }
-    iterator end() noexcept { return {d_packed.end()}; }
-    const_iterator begin() const noexcept { return {d_packed.cbegin()}; }
-    const_iterator end() const noexcept { return {d_packed.cend()}; }
-    const_iterator cbegin() const noexcept { return {d_packed.cbegin()}; }
-    const_iterator cend() const noexcept { return {d_packed.cend()}; }
+    [[nodiscard]] auto each() noexcept
+    {
+        return d_packed | std::views::transform([](auto& element) {
+            return std::make_pair(element.first, std::ref(element.second));
+        });
+    }
+
+    [[nodiscard]] auto each() const noexcept
+    {
+        return d_packed | std::views::transform([](const auto& element) {
+            return std::make_pair(element.first, std::cref(element.second));
+        });
+    }
 };
 
 enum class entity : std::uint64_t {};
@@ -232,90 +218,6 @@ public:
     inline static constexpr std::tuple<apx::meta::tag<Comps>...> tags{};
 
     using handle_type = apx::handle<Comps...>;
-
-    class iterator_sentinel {};
-
-    template <typename... Ts>
-    class iterator;
-
-    template <>
-    class iterator<>
-    {
-    public:
-        using inner_iterator = typename apx::sparse_set<apx::entity>::const_iterator;
-
-    private:
-        inner_iterator d_curr;
-        inner_iterator d_end;
-
-    public:
-        iterator(const registry* reg)
-            : d_curr(reg->d_entities.cbegin())
-            , d_end(reg->d_entities.cend())
-        {}
-
-        apx::entity operator*() const { return *d_curr; }
-        iterator& operator++() { ++d_curr; return *this; }
-        bool valid() const { return d_curr != d_end; }
-        operator bool() const { return valid(); }
-        bool operator==(iterator_sentinel) { return !valid(); }
-
-        iterator begin() { return *this; }
-        iterator_sentinel end() { return {}; }
-        iterator cbegin() { return begin(); }
-        iterator_sentinel cend() { return {}; }
-
-        void each(const std::function<void(apx::entity)>& cb) {
-            for (auto entity : *this) {
-                cb(entity);
-            }
-        }
-    };
-
-    template <typename T, typename... Ts>
-    class iterator<T, Ts...>
-    {
-    public:
-        using inner_iterator = typename apx::sparse_set<T>::const_iterator;
-
-    private:
-        const registry* d_reg;
-        inner_iterator d_curr;
-        inner_iterator d_end;
-
-    public:
-        iterator(const registry* reg)
-            : d_reg(reg)
-            , d_curr(reg->get_comps<T>().cbegin())
-            , d_end(reg->get_comps<T>().cend())
-        {}
-
-        apx::entity operator*() const { return d_reg->from_index(d_curr.index()); }
-        iterator& operator++() {
-            ++d_curr;
-            if constexpr (sizeof...(Ts) > 0) {
-                while (valid() && !d_reg->has_all<Ts...>(**this)) { ++d_curr; }
-            }
-            return *this;
-        }
-        bool valid() const { return d_curr != d_end; }
-        operator bool() const { return valid(); }
-        bool operator==(iterator_sentinel) { return !valid(); }
-
-        iterator begin() { return *this; }
-        iterator_sentinel end() { return {}; }
-        iterator cbegin() { return begin(); }
-        iterator_sentinel cend() { return {}; }
-
-        void each(const std::function<void(apx::entity)>& cb) {
-            for (auto entity : *this) {
-                cb(entity);
-            }
-        }
-    };
-
-    template <typename ...Comps>
-    using const_iterator = iterator<Comps...>;
 
 private:
     using tuple_type = std::tuple<apx::sparse_set<Comps>...>;
@@ -407,7 +309,7 @@ public:
 
     void clear()
     {
-        for (auto entity : d_entities) {
+        for (auto [index, entity] : d_entities.each()) {
             remove_all_components(entity);
         }
         d_entities.clear();
@@ -533,19 +435,36 @@ public:
         return d_entities[index];
     }
 
-    [[nodiscard]] iterator<> all() const noexcept
+    [[nodiscard]] auto all() const noexcept
     {
-        return iterator<>{this};
+        return d_entities.each() | std::views::transform([](const auto& element) {
+            const auto& [index, entity] = element;
+            return entity;
+        });
+    }
+
+    template <typename... Comps>
+    [[nodiscard]] auto view() const noexcept
+    {
+        if constexpr (sizeof...(Comps) == 0) {
+            return all();
+        } else {
+            using Comp = typename apx::meta::get_first<Comps...>::type;
+            const auto entity_view = get_comps<Comp>().each() | std::views::transform([&](const auto& element) {
+                const auto& [index, component] = element;
+                return from_index((std::uint32_t)index);
+            });
+
+            if constexpr (sizeof...(Comps) > 1) {
+                return entity_view | std::views::filter([&](auto entity) { return has_all<Comps...>(entity); });
+            } else {
+                return entity_view;
+            }
+        }
     }
 
     template <typename... Ts>
-    [[nodiscard]] iterator<Ts...> view() const noexcept
-    {
-        return iterator<Ts...>{this};
-    }
-
-    template <typename... Ts>
-    void erase_if(const predicate_t& cb) {
+    void erase_if(const predicate_t& cb) noexcept {
         std::vector<apx::entity> to_delete;
         for (auto entity : view<Ts...>()) {
             if (cb(entity)) { to_delete.push_back(entity); }

--- a/tests/handle.cpp
+++ b/tests/handle.cpp
@@ -49,7 +49,7 @@ TEST(handle, test_add)
     }
 }
 
-TEST(handle, test_erase_if)
+TEST(handle, test_destroy_if)
 // Test removing all but the first element.
 {
     apx::registry<foo> reg;
@@ -59,7 +59,7 @@ TEST(handle, test_erase_if)
     (void)reg.create();
 
     bool passed_first = false;
-    reg.erase_if([&](apx::entity e) {
+    reg.destroy_if([&](apx::entity e) {
         if (!passed_first) {
             passed_first = true;
             return false;

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -241,3 +241,26 @@ TEST(registry, test_add)
         ASSERT_TRUE(reg.has<foo>(e));
     }
 }
+
+TEST(registry, multi_destroy_vector)
+{
+    apx::registry<foo> reg;
+    auto e1 = reg.create();
+    auto e2 = reg.create();
+    auto e3 = reg.create();
+    ASSERT_EQ(reg.size(), 3);
+
+    std::vector v{e1, e2, e3};
+    reg.destroy(v);
+}
+
+TEST(registry, multi_destroy_initializer_list)
+{
+    apx::registry<foo> reg;
+    auto e1 = reg.create();
+    auto e2 = reg.create();
+    auto e3 = reg.create();
+    ASSERT_EQ(reg.size(), 3);
+
+    reg.destroy({e1, e2, e3});
+}

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -189,25 +189,6 @@ TEST(registry_view, view_for_loop_multi)
     ASSERT_EQ(count, 2);
 }
 
-TEST(registry_view, view_callback)
-{
-    apx::registry<foo, bar> reg;
-
-    auto e1 = reg.create();
-    reg.emplace<foo>(e1);
-    reg.emplace<bar>(e1);
-
-    auto e2 = reg.create();
-    reg.emplace<bar>(e2);
-
-    std::size_t count = 0;
-    auto view = reg.view<foo>();
-    view.each([&](apx::entity) {
-        ++count;
-    });
-    ASSERT_EQ(count, 1);
-}
-
 TEST(registry_all, all_for_loop)
 {
     apx::registry<foo, bar> reg;
@@ -223,24 +204,6 @@ TEST(registry_all, all_for_loop)
     for (auto entity : reg.all()) {
         ++count;
     }
-    ASSERT_EQ(count, 2);
-}
-
-TEST(registry_all, all_callback)
-{
-    apx::registry<foo, bar> reg;
-
-    auto e1 = reg.create();
-    reg.emplace<foo>(e1);
-    reg.emplace<bar>(e1);
-
-    auto e2 = reg.create();
-    reg.emplace<bar>(e2);
-
-    std::size_t count = 0;
-    reg.all().each([&](apx::entity) {
-        ++count;
-    });
     ASSERT_EQ(count, 2);
 }
 

--- a/tests/sparse_set.cpp
+++ b/tests/sparse_set.cpp
@@ -26,8 +26,9 @@ TEST(sparse_set, iterate_with_one_element_and_index_check)
     apx::sparse_set<int> set;
     set.insert(2, 5);
 
-    for (auto it = set.begin(); it != set.end(); ++it) {
-        ASSERT_EQ(*it, 5);
-        ASSERT_EQ(it.index(), 2);
+    for (const auto& [index, value] : set.each()) {
+        ASSERT_EQ(index, 2);
+        ASSERT_EQ(value, 5);
+
     }
 }

--- a/tests/sparse_set.cpp
+++ b/tests/sparse_set.cpp
@@ -32,3 +32,15 @@ TEST(sparse_set, iterate_with_one_element_and_index_check)
 
     }
 }
+
+TEST(sparse_set, each_can_modify_elements)
+{
+    apx::sparse_set<int> set;
+    set.insert(1, 5);
+
+    for (auto [index, value] : set.each()) {
+        value = 6;
+    }
+
+    ASSERT_EQ(set[1], 6);
+}


### PR DESCRIPTION
* Remove the iterator implementation and switch to use `std::ranges`. This is just as clean as the original coroutine impl, but now there is no allocation overhead.
* Rename `erase_if` to `destroy_if`.
* Add `std::initializer_list` and `std::span` versions of `registry::destroy`.