### PR TITLE
Add Copy Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ By default this loops over all entities and returns the first one satisfying the
 registry.find<transform>([](auto entity) -> bool { ... });
 ```
 
+### Copying Entities
+It might desirable to duplicate entities within a registry. More generally, given
+two different registries of the same templated type, it may also be useful to be
+able to copy an entity from one registry to another. For this, use `apx::copy`:
+```cpp
+template <typename... Comps>
+entity copy(entity entity, const registry<Comps...>& src, registry<Comps...>& dst);
+```
+The given entity must be a valid entity in the src registry.
+
 ### Deleting Entities via a Predicate
 Deleting entities in a loop is undefined behaviour as you could be modifying the container you are iterating over. To delete a set of entities safely 
 ```cpp

--- a/include/apecs/apecs.hpp
+++ b/include/apecs/apecs.hpp
@@ -464,6 +464,18 @@ public:
     }
 };
 
+template <typename... Comps>
+apx::entity copy(apx::entity entity, const apx::registry<Comps...>& src, apx::registry<Comps...>& dst)
+{
+    auto new_entity = dst.create();
+    apx::meta::for_each(apx::registry<Comps...>::tags, [&]<typename T>(apx::meta::tag<T>) {
+        if (src.has<T>(entity)) {
+            dst.add<T>(new_entity, src.get<T>(entity));
+        }
+    });
+    return new_entity;
+}
+
 }
 
 #endif // APECS_HPP_


### PR DESCRIPTION
* Adds `apx::copy`, a free function for copying entities. Can be used to duplicating an entity within a single registry, or for creating a copy of the entity in a different registry of the same type.